### PR TITLE
Update peerDepdendency of @graphql-tools/utils to allow ^9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "@graphql-tools/utils": "^8.0.0",
+    "@graphql-tools/utils": "^8.0.0 || ^9.0.0",
     "graphql": "^16.0.0",
     "rate-limiter-flexible": "^2.0.0"
   },


### PR DESCRIPTION
Trying to update our dependencies and noticed that this package only allows a peerDepdendency for utils of ^8.0.0. I don't believe anything majorly changed so both should be supported AFAIK