### PR TITLE
Bump rate-limiter-flexible to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "peerDependencies": {
     "@graphql-tools/utils": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "graphql": "^16.0.0",
-    "rate-limiter-flexible": "^2.0.0"
+    "rate-limiter-flexible": "^4.0.0"
   },
   "devDependencies": {
     "@graphql-tools/schema": "10.0.2",


### PR DESCRIPTION
Successfully integrated rate-limiter-flexible 4.0.0 with no issues.
Resolves #384