### PR TITLE
feat: support rate limiting on specific field arguments

### DIFF
--- a/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -15,6 +15,22 @@ exports[`rateLimitDirective limiting a repeated object 1`] = `
 }
 `;
 
+exports[`rateLimitDirective limiting a specific argument on a field 1`] = `
+{
+  "data": {
+    "quote": "The future is something which everyone reaches at the rate of sixty minutes an hour, whatever he does, whoever he is. ― C.S. Lewis",
+  },
+}
+`;
+
+exports[`rateLimitDirective limiting a specific argument on a field 2`] = `
+{
+  "data": {
+    "quote": "The future is something which everyone reaches at the rate of sixty minutes an hour, whatever he does, whoever he is. ― C.S. Lewis",
+  },
+}
+`;
+
 exports[`rateLimitDirective limiting a specific field 1`] = `
 {
   "data": {


### PR DESCRIPTION
resolves #413

## Context

It may be desirable to rate limit a field, but only when passing in a given argument.

### Example: claiming resources during a login mutation

You may want users to be able to claim a coupon using a unique code, during login. But this should be rate limited so as to avoid enumeration or brute force attacks. The same mutation should not be rate-limited when not passing in a code to claim.
